### PR TITLE
NodeManager SR tables

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	branch = master
 [submodule "NodeManager"]
 	path = NodeManager
-	url = git@github.com:RangeNetworks/NodeManager.git
+	url = git@github.com:endaga/NodeManager.git
 	branch = master
 [submodule "CommonLibs"]
 	path = CommonLibs

--- a/apps/sipauthserve.cpp
+++ b/apps/sipauthserve.cpp
@@ -73,8 +73,8 @@ JsonBox::Object nmHandler(JsonBox::Object& request)
 	std::string command = request["command"].getString();
 	std::string action = request["action"].getString();
 
-	if (command.compare("subscribers") == 0) {
-		request["table"] = JsonBox::Value("subscribers");
+	if (command.compare("subscribers") == 0 || command.compare("sip_buddies") == 0 || command.compare("dialdata_table") == 0) {
+		request["table"] = JsonBox::Value(command);
 		response = gJSONDB.query(request);
 	} else {
 		response["code"] = JsonBox::Value(501);


### PR DESCRIPTION
- Making NodeManager submodule point to Endaga repo
- Exposing NodeManager interface for modifying `sip_buddies` and `dialdata_table` tables in the subscriber registry. Prior to this, all NodeManager can access in the subscriber registry is a table join of `sip_buddies` and `dialdata_table` with limited fields.
