### PR TITLE
Add sqlite3 build dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,8 @@
 Source: sipauthserve-public
 Section: comm
 Priority: optional
-Maintainer: Range Networks, Inc. <info@rangenetworks.com>
-Homepage: http://www.rangenetworks.com/
+Maintainer: Endaga, Inc. <hello@endaga.com>
+Homepage: http://www.endaga.com/
 Build-Depends: build-essential, debhelper (>= 7), libsqlite3-dev, libosip2-dev, pkg-config, autoconf, libtool, libzmq3-dev, libzmq3, libcoredumper1, libcoredumper-dev, sqlite3
 Standards-Version: 3.7.3
 
@@ -13,5 +13,5 @@ Priority: optional
 Architecture: any
 Essential: no
 Depends: sqlite3, libosip2-4, libc6, pkg-config, libzmq1, supervisor
-Description: Range Networks - SIP Authorization Server
+Description: Endaga - SIP Authorization Server
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: comm
 Priority: optional
 Maintainer: Range Networks, Inc. <info@rangenetworks.com>
 Homepage: http://www.rangenetworks.com/
-Build-Depends: build-essential, debhelper (>= 7), libsqlite3-dev, libosip2-dev, pkg-config, autoconf, libtool, libzmq3-dev, libzmq3, libcoredumper1, libcoredumper-dev
+Build-Depends: build-essential, debhelper (>= 7), libsqlite3-dev, libosip2-dev, pkg-config, autoconf, libtool, libzmq3-dev, libzmq3, libcoredumper1, libcoredumper-dev, sqlite3
 Standards-Version: 3.7.3
 
 Package: sipauthserve-public

--- a/debian/rules
+++ b/debian/rules
@@ -73,6 +73,7 @@ install-arch:
 
 	# Add here commands to install the arch part of the package into
 	# debian/{package}.
+	$(MAKE) check
 	$(MAKE) DESTDIR=$(CURDIR)/debian/sipauthserve install
 
 	dh_install -s


### PR DESCRIPTION
Adds a sqlite3 build dep which is needed to make `make check` pass. Also clarifies this is not the official Range package.
