### PR TITLE
This fixes dpkg-buildpackage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-sipauthserve (5.0) unstable; urgency=low
+sipauthserve-public (5.0) unstable; urgency=low
 
   * Test
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
-sipauthserve-public (5.0) unstable; urgency=low
+sipauthserve (5.0) unstable; urgency=low
 
-	* Test
+  * Test
 
  -- Range Packager <buildmeister@rangenetworks.com>  Thu, 25 Sep 2014 00:17:42 -0700

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: sipauthserve-public
+Source: sipauthserve
 Section: comm
 Priority: optional
 Maintainer: Endaga, Inc. <hello@endaga.com>
@@ -6,7 +6,7 @@ Homepage: http://www.endaga.com/
 Build-Depends: build-essential, debhelper (>= 7), libsqlite3-dev, libosip2-dev, pkg-config, autoconf, libtool, libzmq3-dev, libzmq3, libcoredumper1, libcoredumper-dev, sqlite3
 Standards-Version: 3.7.3
 
-Package: sipauthserve-public
+Package: sipauthserve
 Provides: sipauthserve
 Section: comm
 Priority: optional

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: build-essential, debhelper (>= 7), libsqlite3-dev, libosip2-dev, 
 Standards-Version: 3.7.3
 
 Package: sipauthserve-public
-Provides: sipauthserve-public
+Provides: sipauthserve
 Section: comm
 Priority: optional
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: sipauthserve
+Source: sipauthserve-public
 Section: comm
 Priority: optional
 Maintainer: Endaga, Inc. <hello@endaga.com>
@@ -6,8 +6,8 @@ Homepage: http://www.endaga.com/
 Build-Depends: build-essential, debhelper (>= 7), libsqlite3-dev, libosip2-dev, pkg-config, autoconf, libtool, libzmq3-dev, libzmq3, libcoredumper1, libcoredumper-dev, sqlite3
 Standards-Version: 3.7.3
 
-Package: sipauthserve
-Provides: sipauthserve
+Package: sipauthserve-public
+Provides: sipauthserve-public
 Section: comm
 Priority: optional
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -20,11 +20,13 @@ export DH_ALWAYS_EXCLUDE=.svn:.git
 export DH_OPTIONS
 
 configure:
+	./autogen.sh # --verbose
 
 config: configure-stamp
 configure-stamp: configure
 	dh_testdir
 	# Add here commands to configure the package.
+	./configure $(confflags)
 	touch configure-stamp
 
 #Architecture

--- a/debian/rules
+++ b/debian/rules
@@ -74,7 +74,7 @@ install-arch:
 	# Add here commands to install the arch part of the package into
 	# debian/{package}.
 	$(MAKE) check
-	$(MAKE) DESTDIR=$(CURDIR)/debian/sipauthserve install
+	$(MAKE) DESTDIR=$(CURDIR)/debian/sipauthserve-public install
 
 	dh_install -s
 

--- a/debian/rules
+++ b/debian/rules
@@ -98,7 +98,7 @@ binary-common:
 #	dh_installcron
 #	dh_installinfo
 	dh_installman
-	dh_link
+#       dh_link
 #	dh_strip
 	dh_compress
 	dh_fixperms


### PR DESCRIPTION
- Release name is sipauthserve, no public suffix. That was breaking things.
- Disabled dh_link since that was doing funny things like deleting the
- binary before packaging it
