### PR TITLE
No longer depend on libosip2-4

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,6 @@ Section: comm
 Priority: optional
 Architecture: any
 Essential: no
-Depends: sqlite3, libosip2-4, libc6, pkg-config, libzmq1, supervisor
+Depends: sqlite3, libosip2-dev, libc6, pkg-config, libzmq1, supervisor
 Description: Endaga - SIP Authorization Server
 


### PR DESCRIPTION
We don't need a dependency on libosip2-4 anymore; this should work fine.
